### PR TITLE
Adding missing constructor to cli::command

### DIFF
--- a/src/include/cli.hpp
+++ b/src/include/cli.hpp
@@ -297,6 +297,7 @@ namespace qOS {
                 command( command const& ) = delete;
                 void operator=( command const& ) = delete;
             public:
+                command() {}
                 virtual ~command() {}
             friend class qOS::commandLineInterface;
         };


### PR DESCRIPTION
Given the docs: https://kmilo17pet.github.io/QuarkTS-cpp/q_atcli.html#q_atcli_example1

The following is not possible right now:

```cpp
cli::command AT_INFO;
```

It is not possible because command has no constructor.